### PR TITLE
Add an environment for the separate test script

### DIFF
--- a/script/GLWrapper.jl
+++ b/script/GLWrapper.jl
@@ -23,7 +23,7 @@ export GeodGeodesic,
        geod_init,
        geod_inverse
 
-const LIBGEOD = "/opt/local/lib/proj6/lib/libproj.dylib"
+const LIBGEOD = "/opt/local/lib/proj9/lib/libproj.dylib"
 
 struct Cdouble6
     x1::Cdouble

--- a/script/Project.toml
+++ b/script/Project.toml
@@ -1,0 +1,7 @@
+[deps]
+GeographicLib = "c96ba436-a6fe-11e9-10ab-c9f3919c93d1"
+PyCall = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
+
+[compat]
+PyCall = "1"
+julia = "1.6"


### PR DESCRIPTION
The tests which are controlled by a script in `script/` previously
relied on having somehow activated an environment with PyCall
before running the script.  Fix that so activating (and if needed
instantiating) the environment can be done.

Also update the hard-coded path to `libproj` in `GLWrapper.jl`.
